### PR TITLE
Add light mode toggle to site

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -43,6 +43,14 @@
             );
         }
 
+        body.light-mode {
+            --dark-bg: #ffffff;
+            --darker-bg: #f5f5f5;
+            --card-bg: #f0f0f0;
+            --text-light: #1a1a2e;
+            --text-muted: #555555;
+        }
+
         .dashboard-container {
             display: grid;
            
@@ -80,6 +88,23 @@
         .crown {
             font-size: 1.8rem;
             color: var(--accent);
+        }
+
+        .theme-toggle {
+            background: none;
+            border: 2px solid var(--claret);
+            color: var(--text-muted);
+            padding: 0.4rem 0.8rem;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 1rem;
+            transition: all 0.3s ease;
+            margin-left: 1rem;
+        }
+
+        .theme-toggle:hover {
+            color: var(--text-light);
+            border-color: var(--text-light);
         }
 
         .admin-badge {
@@ -578,11 +603,12 @@
         <!-- Sidebar -->
         <nav class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">
-                    <span class="crown">👑</span>
-                    Royal Raffles
-                    <span class="admin-badge">ADMIN</span>
-                </div>
+             <div class="logo">
+                 <span class="crown">👑</span>
+                 Royal Raffles
+                 <span class="admin-badge">ADMIN</span>
+             </div>
+                <button id="themeToggle" class="theme-toggle" aria-label="Toggle light mode">🌙</button>
             </div>
             <ul class="sidebar-nav">
                 <li><a href="#" class="nav-link active" data-section="dashboard">
@@ -1464,6 +1490,27 @@
         document.addEventListener('DOMContentLoaded', function() {
             showSection('dashboard');
         });
+    </script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const themeToggle = document.getElementById('themeToggle');
+        const setTheme = (theme) => {
+            if (theme === 'light') {
+                document.body.classList.add('light-mode');
+                themeToggle.textContent = '🌞';
+            } else {
+                document.body.classList.remove('light-mode');
+                themeToggle.textContent = '🌙';
+            }
+        };
+        const savedTheme = localStorage.getItem('theme') || 'dark';
+        setTheme(savedTheme);
+        themeToggle.addEventListener('click', () => {
+            const newTheme = document.body.classList.contains('light-mode') ? 'dark' : 'light';
+            setTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+        });
+    });
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -46,6 +46,14 @@
         background-blend-mode: overlay;
     }
 
+    body.light-mode {
+        --dark-bg: #ffffff;
+        --darker-bg: #f5f5f5;
+        --card-bg: #f0f0f0;
+        --text-light: #1a1a2e;
+        --text-muted: #555555;
+    }
+
 
     .container {
         max-width: 1400px;
@@ -141,6 +149,23 @@
         margin: 3px 0;
         transition: 0.3s;
         border-radius: 2px;
+    }
+
+    .theme-toggle {
+        background: none;
+        border: 2px solid var(--claret);
+        color: var(--text-muted);
+        padding: 0.4rem 0.8rem;
+        border-radius: 5px;
+        cursor: pointer;
+        font-size: 1rem;
+        transition: all 0.3s ease;
+        margin-left: 1rem;
+    }
+
+    .theme-toggle:hover {
+        color: var(--text-light);
+        border-color: var(--text-light);
     }
 
     /* Main Content */
@@ -1308,6 +1333,7 @@
                 <a class="cta-button">Login</a>
             </li>
         </ul>
+        <button id="themeToggle" class="theme-toggle" aria-label="Toggle light mode">🌙</button>
         <div class="mobile-menu" id="mobileMenu">
             <span></span>
             <span></span>
@@ -1883,5 +1909,26 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
     </script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const themeToggle = document.getElementById('themeToggle');
+    const setTheme = (theme) => {
+        if (theme === 'light') {
+            document.body.classList.add('light-mode');
+            themeToggle.textContent = '🌞';
+        } else {
+            document.body.classList.remove('light-mode');
+            themeToggle.textContent = '🌙';
+        }
+    };
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    setTheme(savedTheme);
+    themeToggle.addEventListener('click', () => {
+        const newTheme = document.body.classList.contains('light-mode') ? 'dark' : 'light';
+        setTheme(newTheme);
+        localStorage.setItem('theme', newTheme);
+    });
+});
+</script>
 </body>
 </html>

--- a/lastwinner.html
+++ b/lastwinner.html
@@ -40,6 +40,14 @@
             background-blend-mode: overlay;
         }
 
+        body.light-mode {
+            --dark-bg: #ffffff;
+            --darker-bg: #f5f5f5;
+            --card-bg: #f0f0f0;
+            --text-light: #1a1a2e;
+            --text-muted: #555555;
+        }
+
         .container {
             max-width: 1400px;
             margin: 0 auto;
@@ -111,6 +119,23 @@
         .nav-links a.active {
             color: var(--accent);
             background: rgba(255, 215, 0, 0.1);
+        }
+
+        .theme-toggle {
+            background: none;
+            border: 2px solid var(--claret);
+            color: var(--text-muted);
+            padding: 0.4rem 0.8rem;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 1rem;
+            transition: all 0.3s ease;
+            margin-left: 1rem;
+        }
+
+        .theme-toggle:hover {
+            color: var(--text-light);
+            border-color: var(--text-light);
         }
 
         /* Main Content */
@@ -486,9 +511,10 @@
             <ul class="nav-links">
                 <li><a href="#home">Home</a></li>
                 <li><a href="#raffles">Raffles</a></li>
-                <li><a href="#winners" class="active">Winners</a></li>
-                <li><a href="#login">Login</a></li>
-            </ul>
+          <li><a href="#winners" class="active">Winners</a></li>
+          <li><a href="#login">Login</a></li>
+          </ul>
+            <button id="themeToggle" class="theme-toggle" aria-label="Toggle light mode">🌙</button>
         </nav>
     </header>
 
@@ -795,6 +821,27 @@
                 }
             });
         });
+    </script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const themeToggle = document.getElementById('themeToggle');
+        const setTheme = (theme) => {
+            if (theme === 'light') {
+                document.body.classList.add('light-mode');
+                themeToggle.textContent = '🌞';
+            } else {
+                document.body.classList.remove('light-mode');
+                themeToggle.textContent = '🌙';
+            }
+        };
+        const savedTheme = localStorage.getItem('theme') || 'dark';
+        setTheme(savedTheme);
+        themeToggle.addEventListener('click', () => {
+            const newTheme = document.body.classList.contains('light-mode') ? 'dark' : 'light';
+            setTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+        });
+    });
     </script>
 </body>
 </html>

--- a/raffle.html
+++ b/raffle.html
@@ -41,6 +41,14 @@
             background-blend-mode: overlay;
         }
 
+        body.light-mode {
+            --dark-bg: #ffffff;
+            --darker-bg: #f5f5f5;
+            --card-bg: #f0f0f0;
+            --text-light: #1a1a2e;
+            --text-muted: #555555;
+        }
+
         .container {
             max-width: 1400px;
             margin: 0 auto;
@@ -107,6 +115,23 @@
         .nav-links a:hover {
             color: var(--text-light);
             text-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+        }
+
+        .theme-toggle {
+            background: none;
+            border: 2px solid var(--claret);
+            color: var(--text-muted);
+            padding: 0.4rem 0.8rem;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 1rem;
+            transition: all 0.3s ease;
+            margin-left: 1rem;
+        }
+
+        .theme-toggle:hover {
+            color: var(--text-light);
+            border-color: var(--text-light);
         }
 
         .back-button {
@@ -633,12 +658,13 @@
                 <li><a href="#home">Home</a></li>
                 <li><a href="#raffles">Raffles</a></li>
                 <li><a href="#winners">Winners</a></li>
-                <li>
-                <a class="cta-button">Login</a>
-            </li>
-            </ul>
-        </nav>
-    </header>
+          <li>
+          <a class="cta-button">Login</a>
+      </li>
+      </ul>
+            <button id="themeToggle" class="theme-toggle" aria-label="Toggle light mode">🌙</button>
+      </nav>
+  </header>
 
     <!-- Main Content -->
     <main class="main">
@@ -887,6 +913,27 @@
                 }
             });
         });
+    </script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const themeToggle = document.getElementById('themeToggle');
+        const setTheme = (theme) => {
+            if (theme === 'light') {
+                document.body.classList.add('light-mode');
+                themeToggle.textContent = '🌞';
+            } else {
+                document.body.classList.remove('light-mode');
+                themeToggle.textContent = '🌙';
+            }
+        };
+        const savedTheme = localStorage.getItem('theme') || 'dark';
+        setTheme(savedTheme);
+        themeToggle.addEventListener('click', () => {
+            const newTheme = document.body.classList.contains('light-mode') ? 'dark' : 'light';
+            setTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+        });
+    });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add light mode CSS variables and theme toggle button across pages
- persist user theme preference in localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ba3c8d6dc8332a2d3a5041bfc4f62