### PR TITLE
Add simulated login and user profile with credits

### DIFF
--- a/index.html
+++ b/index.html
@@ -1302,7 +1302,7 @@
             <li><a href="#" class="nav-link" data-page="dashboard">Dashboard</a></li>
             <li><a href="#" class="nav-link" data-page="faq">FAQ</a></li>
             <li>
-                <a class="cta-button">Login</a>
+                <a id="loginLink" class="cta-button" href="login.html">Login</a>
             </li>
         </ul>
         <button id="themeToggle" class="theme-toggle" aria-label="Toggle light mode">🌙</button>
@@ -1896,6 +1896,12 @@ document.addEventListener('DOMContentLoaded', function() {
         setTheme(newTheme);
         localStorage.setItem('theme', newTheme);
     });
+    const loginLink = document.getElementById('loginLink');
+    const username = localStorage.getItem('rr_username');
+    if (loginLink && username) {
+        loginLink.textContent = 'Profile';
+        loginLink.href = 'profile.html';
+    }
 });
 </script>
 </body>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login - Royal Raffles UK</title>
+    <style>
+        body {
+            font-family: 'Kanit', sans-serif;
+            background: #0d0d0d;
+            color: #fff;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .login-container {
+            background: #1e1e1e;
+            padding: 2rem;
+            border-radius: 10px;
+            box-shadow: 0 0 15px rgba(0,0,0,0.5);
+            width: 300px;
+        }
+        .login-container h1 {
+            text-align: center;
+            margin-bottom: 1.5rem;
+            background: linear-gradient(90deg, #7f1734, #0055a5);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .login-container input {
+            width: 100%;
+            padding: 0.5rem;
+            margin-bottom: 1rem;
+            border: none;
+            border-radius: 5px;
+        }
+        .login-container button {
+            width: 100%;
+            padding: 0.5rem;
+            background: #7f1734;
+            border: none;
+            color: #fff;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+        .login-container button:hover {
+            background: #0055a5;
+        }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <h1>Login</h1>
+        <input type="text" id="username" placeholder="Username">
+        <input type="password" id="password" placeholder="Password">
+        <button onclick="login()">Login</button>
+    </div>
+    <script>
+        function login() {
+            const username = document.getElementById('username').value;
+            const password = document.getElementById('password').value;
+            if (!username || !password) {
+                alert('Please enter username and password');
+                return;
+            }
+            localStorage.setItem('rr_username', username);
+            if (!localStorage.getItem('rr_credits')) {
+                localStorage.setItem('rr_credits', '0');
+            }
+            window.location.href = 'profile.html';
+        }
+    </script>
+</body>
+</html>

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Your Profile - Royal Raffles UK</title>
+    <style>
+        body {
+            font-family: 'Kanit', sans-serif;
+            background: #0d0d0d;
+            color: #fff;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .profile-container {
+            background: #1e1e1e;
+            padding: 2rem;
+            border-radius: 10px;
+            box-shadow: 0 0 15px rgba(0,0,0,0.5);
+            width: 320px;
+            text-align: center;
+        }
+        .profile-container h1 {
+            margin-bottom: 1rem;
+            background: linear-gradient(90deg, #7f1734, #0055a5);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .profile-container button {
+            width: 100%;
+            padding: 0.5rem;
+            margin-top: 1rem;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+        #addFunds {
+            background: #7f1734;
+            color: #fff;
+        }
+        #addFunds:hover {
+            background: #0055a5;
+        }
+        #logout {
+            background: #333;
+            color: #fff;
+        }
+        #logout:hover {
+            background: #555;
+        }
+    </style>
+</head>
+<body>
+    <div class="profile-container">
+        <h1>Welcome, <span id="username"></span></h1>
+        <p>Credits: £<span id="credits">0</span></p>
+        <button id="addFunds">Add Funds via PayPal (Simulated)</button>
+        <button id="logout">Logout</button>
+    </div>
+    <script>
+        function loadProfile() {
+            const username = localStorage.getItem('rr_username');
+            if (!username) {
+                window.location.href = 'login.html';
+                return;
+            }
+            document.getElementById('username').textContent = username;
+            const credits = localStorage.getItem('rr_credits') || '0';
+            document.getElementById('credits').textContent = credits;
+        }
+        document.getElementById('addFunds').addEventListener('click', function() {
+            const amount = prompt('Enter amount to add (simulated PayPal):');
+            const value = parseFloat(amount);
+            if (isNaN(value) || value <= 0) {
+                alert('Invalid amount');
+                return;
+            }
+            let credits = parseFloat(localStorage.getItem('rr_credits') || '0');
+            credits += value;
+            localStorage.setItem('rr_credits', credits.toFixed(2));
+            document.getElementById('credits').textContent = credits.toFixed(2);
+        });
+        document.getElementById('logout').addEventListener('click', function() {
+            localStorage.removeItem('rr_username');
+            localStorage.removeItem('rr_credits');
+            window.location.href = 'index.html';
+        });
+        loadProfile();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link navigation to new login page and swap to profile link when signed in
- create standalone login page storing user name and credits in local storage
- add profile page with simulated PayPal funding, credit display, and logout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a7c05e148332b55e3027f3e4385a