### PR TITLE
Integrate dashboard as user profile with simulated credits

### DIFF
--- a/index.html
+++ b/index.html
@@ -1302,7 +1302,7 @@
             <li><a href="#" class="nav-link" data-page="dashboard">Dashboard</a></li>
             <li><a href="#" class="nav-link" data-page="faq">FAQ</a></li>
             <li>
-                <a class="cta-button">Login</a>
+                <a id="loginLink" class="cta-button" href="login.html">Login</a>
             </li>
         </ul>
         <button id="themeToggle" class="theme-toggle" aria-label="Toggle light mode">🌙</button>
@@ -1445,9 +1445,16 @@
 
 
             <!-- User Dashboard -->
-            <div id="dashboard" class="page">
+           <div id="dashboard" class="page">
                 <h1 style="color: white; text-align: center; margin-bottom: 2rem;">Your Dashboard</h1>
-                
+
+                <div class="dashboard-section">
+                    <h2>Welcome, <span id="profileUsername"></span></h2>
+                    <p>Credits: £<span id="profileCredits">0</span></p>
+                    <button id="addFunds" class="cta-button">Add Funds via PayPal (Simulated)</button>
+                    <button id="logout" class="cta-button secondary" style="margin-left: 1rem;">Logout</button>
+                </div>
+
                 <div class="dashboard-section">
                     <h2>Active Entries</h2>
                     <div class="entries-list">
@@ -1896,7 +1903,56 @@ document.addEventListener('DOMContentLoaded', function() {
         setTheme(newTheme);
         localStorage.setItem('theme', newTheme);
     });
+    const loginLink = document.getElementById('loginLink');
+    const username = localStorage.getItem('rr_username');
+    if (loginLink && username) {
+        loginLink.textContent = 'Profile';
+        loginLink.href = '#';
+        loginLink.addEventListener('click', function(e) {
+            e.preventDefault();
+            showPage('dashboard');
+        });
+
+        updateProfileInfo();
+
+        document.getElementById('addFunds').addEventListener('click', function() {
+            const amount = prompt('Enter amount to add (simulated PayPal):');
+            const value = parseFloat(amount);
+            if (isNaN(value) || value <= 0) {
+                alert('Invalid amount');
+                return;
+            }
+            let credits = parseFloat(localStorage.getItem('rr_credits') || '0');
+            credits += value;
+            localStorage.setItem('rr_credits', credits.toFixed(2));
+            updateProfileInfo();
+        });
+
+        document.getElementById('logout').addEventListener('click', function() {
+            localStorage.removeItem('rr_username');
+            localStorage.removeItem('rr_credits');
+            localStorage.removeItem('rr_show_dashboard');
+            window.location.href = 'index.html';
+        });
+
+        if (localStorage.getItem('rr_show_dashboard')) {
+            showPage('dashboard');
+            localStorage.removeItem('rr_show_dashboard');
+        }
+    }
 });
+
+function updateProfileInfo() {
+    const nameEl = document.getElementById('profileUsername');
+    const creditEl = document.getElementById('profileCredits');
+    if (nameEl) {
+        nameEl.textContent = localStorage.getItem('rr_username') || '';
+    }
+    if (creditEl) {
+        const credits = parseFloat(localStorage.getItem('rr_credits') || '0');
+        creditEl.textContent = credits.toFixed(2);
+    }
+}
 </script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login - Royal Raffles UK</title>
+    <style>
+        body {
+            font-family: 'Kanit', sans-serif;
+            background: #0d0d0d;
+            color: #fff;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .login-container {
+            background: #1e1e1e;
+            padding: 2rem;
+            border-radius: 10px;
+            box-shadow: 0 0 15px rgba(0,0,0,0.5);
+            width: 300px;
+        }
+        .login-container h1 {
+            text-align: center;
+            margin-bottom: 1.5rem;
+            background: linear-gradient(90deg, #7f1734, #0055a5);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .login-container input {
+            width: 100%;
+            padding: 0.5rem;
+            margin-bottom: 1rem;
+            border: none;
+            border-radius: 5px;
+        }
+        .login-container button {
+            width: 100%;
+            padding: 0.5rem;
+            background: #7f1734;
+            border: none;
+            color: #fff;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+        .login-container button:hover {
+            background: #0055a5;
+        }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <h1>Login</h1>
+        <input type="text" id="username" placeholder="Username">
+        <input type="password" id="password" placeholder="Password">
+        <button onclick="login()">Login</button>
+    </div>
+    <script>
+        function login() {
+            const username = document.getElementById('username').value;
+            const password = document.getElementById('password').value;
+            if (!username || !password) {
+                alert('Please enter username and password');
+                return;
+            }
+            localStorage.setItem('rr_username', username);
+            if (!localStorage.getItem('rr_credits')) {
+                localStorage.setItem('rr_credits', '0');
+            }
+            localStorage.setItem('rr_show_dashboard', 'true');
+            window.location.href = 'index.html';
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- embed user welcome, credits, add funds, and logout controls directly into the dashboard
- redirect login to index and show dashboard as profile, removing standalone profile page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a7c05e148332b55e3027f3e4385a